### PR TITLE
Avoid overwriting existing fuel categories

### DIFF
--- a/code/data/vehicle-fuel.lua
+++ b/code/data/vehicle-fuel.lua
@@ -61,14 +61,18 @@ local function modify_prototype(prototype)
 	local b = prototype.burner
 	if not b then return end
 
-	if b.fuel_categories and not has_value(b.fuel_categories, "battery") then
-		table.insert(b.fuel_categories, "battery")
-	elseif b.fuel_category and b.fuel_category ~= "battery" then
-		b.fuel_categories = { b.fuel_category, "battery"}
-		b.fuel_category = nil
+	if b.fuel_categories then
+		if not has_value(b.fuel_categories, "battery") then
+			table.insert(b.fuel_categories, "battery")
+		end
+	elseif b.fuel_category then
+		if b.fuel_category ~= "battery" then
+			b.fuel_categories = { b.fuel_category, "battery" }
+			b.fuel_category = nil
+		end
 	else
-        b.fuel_categories = { "chemical", "battery"} -- no fuel_category means default = "chemical"
-    end
+		b.fuel_categories = { "chemical", "battery" } -- no fuel_category means default = "chemical"
+	end
 
 	if not b.burnt_inventory_size or b.burnt_inventory_size < slot_count then
 		b.burnt_inventory_size = slot_count


### PR DESCRIPTION
Previously, if the `fuel_categories` is present and contains `battery` it would replace the entire section instead of ignoring the prototype:

````lua
b.fuel_categories = { "battery"} 

if b.fuel_categories and not has_value(b.fuel_categories, "battery") -> if true and not true -> false
elseif b.fuel_category and b.fuel_category ~= "battery" then -> false and false -> false
else -> overwritte fuel_categories with { "chemical", "battery"}
````