### PR TITLE
Support Better Train System mod

### DIFF
--- a/code/data/vehicle-fuel.lua
+++ b/code/data/vehicle-fuel.lua
@@ -28,8 +28,10 @@ local vehicle_matches = {
 	locomotive = {
 		-- Angel's Mass Transit
 		"^smelting%-locomotive",
-        "^petro%-locomotive",
-        "^crawler%-locomotive",
+		"^petro%-locomotive",
+		"^crawler%-locomotive",
+		-- Better Train System
+		"^locomotive%-mk",
 	},
 	car = {
 		-- AAI

--- a/info.json
+++ b/info.json
@@ -23,7 +23,8 @@
         "? aai-vehicles-flame-tumbler",
         "? aai-vehicles-hauler",
         "? aai-vehicles-laser-tank",
-        "? aai-vehicles-warden"
+        "? aai-vehicles-warden",
+        "? better-train-system"
     ],
     "package": {
         "ignore": [".git", ".github", ".vscode", ".kakrc", "*.xcf", "*.kra"]


### PR DESCRIPTION
Add supports for the [Better Train System](https://mods.factorio.com/mod/better-train-system) mod.

- `locomotive-mk2`
- `locomotive-mk3`
- `locomotive-mk4`

This needs https://github.com/RedRafe/better-train-system/pull/1/files to be merged as well.

<details>
<summary>Workaround</summary>

It is possible to implement an (easy) workaround in this library as well, but I would rather like to fix the actual error (having both `fuel_categories` and `fuel_category`)

````diff
--- a/code/data/vehicle-fuel.lua
+++ b/code/data/vehicle-fuel.lua
@@ -65,6 +65,7 @@ local function modify_prototype(prototype)

        if b.fuel_categories and not has_value(b.fuel_categories, "battery") then
                table.insert(b.fuel_categories, "battery")
+               b.fuel_category = nil
        elseif b.fuel_category and b.fuel_category ~= "battery" then
                b.fuel_categories = { b.fuel_category, "battery"}
                b.fuel_category = nil
````

Note that this workaround should be applied after #2, then it would look like this:

````diff
--- a/code/data/vehicle-fuel.lua
+++ b/code/data/vehicle-fuel.lua
@@ -64,6 +64,7 @@ local function modify_prototype(prototype)
        if b.fuel_categories then
                if not has_value(b.fuel_categories, "battery") then
                        table.insert(b.fuel_categories, "battery")
+                       b.fuel_category = nil
                end
        elseif b.fuel_category
                if b.fuel_category ~= "battery" then
````

</details>